### PR TITLE
🔧 Adiciona 'task_definition.json' ao .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+integration/task_definition.json
 coverage.out
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/integration/commands/prepare.py
+++ b/integration/commands/prepare.py
@@ -2,6 +2,8 @@
 This script is used to populate the system with data for testing purposes.
 It is used to create flow definitions, task definitions, and start a flow instance.
 """
+import json
+
 from utils import client
 
 
@@ -88,3 +90,5 @@ if pre_create:
     task_def_ref_id = response_task_definition.json()["reference_id"]
 
     print("Task definition created: ", response_task_definition.json())
+    with open("task_definition.json", "w") as f:
+        f.write(json.dumps(response_task_definition.json(), indent=4))

--- a/integration/commands/start.py
+++ b/integration/commands/start.py
@@ -1,8 +1,16 @@
 """
-
+This script is used to start a flow instance.
 """
+import os
+import json
+
 from utils import client
 
+if not os.path.exists("task_definition.json"):
+    raise Exception("task_definition.json not found")
+
+with open("task_definition.json", "r") as f:
+    task_definition_data = json.load(f)
 
 flow_instance_data = {
     "input_data": {
@@ -10,7 +18,7 @@ flow_instance_data = {
     },
 }
 
-flow_definition_ref_id = "f29c8333-2e2e-4690-90e1-aa86fdaa78ef"
+flow_definition_ref_id = task_definition_data["flow_definition_ref_id"]
 
 response_flow_instance = client().post(f"/flows/instances/{flow_definition_ref_id}/start", json=flow_instance_data)
 assert response_flow_instance.status_code == 201


### PR DESCRIPTION
✨ (prepare.py): Adiciona a funcionalidade de salvar a resposta da definição de tarefa em 'task_definition.json'
✨ (start.py): Adiciona a funcionalidade de ler a definição de tarefa de 'task_definition.json' e usar o 'flow_definition_ref_id' para iniciar a instância de fluxo